### PR TITLE
Explicitly follow 301/302

### DIFF
--- a/src/components/Resolver.tsx
+++ b/src/components/Resolver.tsx
@@ -24,8 +24,13 @@ type Info = {
 };
 
 const getLnurl = async (lnurl: string): Promise<Info> => {
-  const res = await fetch(lnurl);
+  const res = await fetch(lnurl, { redirect: "follow" }); // <-- Explicitly follow 301/302
+  if (!res.ok) {
+    throw new Error(`Failed to fetch LNURL: ${res.statusText}`);
+  }
+
   const data = await res.json();
+
 
   if (data.status === "ERROR") {
     throw "LNURL threw error";


### PR DESCRIPTION
This PR should help with following 301/302, but please check before merging, as I'm not a dev.

An example:

the address pay@davidcoen.it redirects to pay@btcpay.davidcoen.it with 301 and the tool resolves 

```
LNURL
url: https://btcpay.davidcoen.it/.well-known/lnurlp/pay
callback: https://btcpay.davidcoen.it/BTC/UILNURL/pay/lnaddress/pay
metadata: [["text/identifier","pay@btcpay.davidcoen.it"],["text/plain","Paid to DAVIDCOEN.IT (Order ID: )"]]
tag: payRequest
minSendable: 1000
maxSendable: 612000000000
commentAllowed: 2000

```
for the latter, if entered directly.

However, it is only able to resolve
```
BIP-353
offer: lno1zrxq8pjw7qjlm68mtp7e3yvxee4y5xrgjhhyf2fxhlphpckrvevh50u0qffqdtuhyd77jpju7prz0qvkcm0xfzfpz844z9dwkaexuapm3e66vqsrxkhw43wz8wfa349nyl2wcsdp2u62ykz4lzuke37p75f4x286v6eqqva25lyzapjs7h424f7v65hv3k539558aqdztn24tjtkyqrrnr3f4vxwxhz0hhrkmzt4mz228sgs3tjl2vzhq0y3s4g8c65nvl35gyy2r833d6qaf64e2qwkey8zkm2q4yln60xgkqqsz8u6nrn984hru24yunnk0p093c
``` 
if you enter pay@davidcoen.it.

If the tool checks for redirects, it should be able to resolve and show both.